### PR TITLE
Add support for WireMock client

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,14 +33,14 @@ dependencies {
     implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
 
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
-    api("com.github.tomakehurst:wiremock:2.27.1")
+    api("com.github.tomakehurst:wiremock-jre8:2.33.2")
 
     testImplementation("io.rest-assured:rest-assured:4.3.0")
     testImplementation("io.rest-assured:json-path:4.3.0")
     testImplementation("io.rest-assured:kotlin-extensions:4.3.0")
     testImplementation("org.junit.jupiter:junit-jupiter:5.6.2")
     testImplementation("io.mockk:mockk:1.10.0")
-    testImplementation("com.github.tomakehurst:wiremock-jre8:2.32.0")
+    testImplementation("com.github.tomakehurst:wiremock-jre8:2.33.2")
 }
 
 tasks.test {

--- a/src/main/kotlin/com/marcinziolo/kotlin/wiremock/WireMockInstance.kt
+++ b/src/main/kotlin/com/marcinziolo/kotlin/wiremock/WireMockInstance.kt
@@ -3,29 +3,36 @@ package com.marcinziolo.kotlin.wiremock
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.MappingBuilder
 import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.junit.DslWrapper
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
 import java.util.UUID
 
-sealed class WireMockInstance {
-    abstract fun stubFor(mappingBuilder: MappingBuilder): StubMapping
-    abstract fun removeStubMapping(stubMapping: StubMapping)
-    abstract fun getSingleStubMapping(uuid: UUID): StubMapping
+interface WireMockInstance {
+    fun stubFor(mappingBuilder: MappingBuilder): StubMapping
+    fun removeStubMapping(stubMapping: StubMapping)
+    fun getSingleStubMapping(uuid: UUID): StubMapping
 }
 
-object WiremockDefaultInstance: WireMockInstance() {
+class WiremockDefaultInstance: WireMockInstance {
     override fun stubFor(mappingBuilder: MappingBuilder) = WireMock.stubFor(mappingBuilder)
     override fun removeStubMapping(stubMapping: StubMapping) = WireMock.removeStub(stubMapping)
     override fun getSingleStubMapping(uuid: UUID) = WireMock.getSingleStubMapping(uuid)
 }
 
-class WiremockServerInstance(private val wireMockServer: WireMockServer): WireMockInstance() {
+class WiremockServerInstance(private val wireMockServer: WireMockServer): WireMockInstance {
     override fun stubFor(mappingBuilder: MappingBuilder) = wireMockServer.stubFor(mappingBuilder)
     override fun removeStubMapping(stubMapping: StubMapping) = wireMockServer.removeStub(stubMapping)
     override fun getSingleStubMapping(uuid: UUID) = wireMockServer.getSingleStubMapping(uuid)
 }
 
-class WiremockClientInstance(private val wireMock: WireMock): WireMockInstance() {
+class WiremockClientInstance(private val wireMock: WireMock): WireMockInstance {
     override fun stubFor(mappingBuilder: MappingBuilder) = wireMock.register(mappingBuilder)
     override fun removeStubMapping(stubMapping: StubMapping) = wireMock.removeStubMapping(stubMapping)
     override fun getSingleStubMapping(uuid: UUID) = wireMock.getStubMapping(uuid).item
+}
+
+class WiremockDslWrapperInstance(private val dslWrapper: DslWrapper): WireMockInstance {
+    override fun stubFor(mappingBuilder: MappingBuilder) = dslWrapper.stubFor(mappingBuilder)
+    override fun removeStubMapping(stubMapping: StubMapping) = dslWrapper.removeStub(stubMapping)
+    override fun getSingleStubMapping(uuid: UUID) = dslWrapper.getSingleStubMapping(uuid)
 }

--- a/src/main/kotlin/com/marcinziolo/kotlin/wiremock/WireMockInstance.kt
+++ b/src/main/kotlin/com/marcinziolo/kotlin/wiremock/WireMockInstance.kt
@@ -23,3 +23,9 @@ class WiremockServerInstance(private val wireMockServer: WireMockServer): WireMo
     override fun removeStubMapping(stubMapping: StubMapping) = wireMockServer.removeStub(stubMapping)
     override fun getSingleStubMapping(uuid: UUID) = wireMockServer.getSingleStubMapping(uuid)
 }
+
+class WiremockClientInstance(private val wireMock: WireMock): WireMockInstance() {
+    override fun stubFor(mappingBuilder: MappingBuilder) = wireMock.register(mappingBuilder)
+    override fun removeStubMapping(stubMapping: StubMapping) = wireMock.removeStubMapping(stubMapping)
+    override fun getSingleStubMapping(uuid: UUID) = wireMock.getStubMapping(uuid).item
+}

--- a/src/main/kotlin/com/marcinziolo/kotlin/wiremock/api.kt
+++ b/src/main/kotlin/com/marcinziolo/kotlin/wiremock/api.kt
@@ -3,6 +3,7 @@ package com.marcinziolo.kotlin.wiremock
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.MappingBuilder
 import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.junit.DslWrapper
 import com.github.tomakehurst.wiremock.matching.UrlPathPattern
 import com.marcinziolo.kotlin.wiremock.mapper.decorateResponseDefinitionBuilder
 import com.marcinziolo.kotlin.wiremock.mapper.toMappingBuilder
@@ -21,6 +22,17 @@ fun WireMock.head(specifyRequest: SpecifyRequest) = requestServerBuilderStep(spe
 fun WireMock.options(specifyRequest: SpecifyRequest) = requestServerBuilderStep(specifyRequest, WireMock::options)
 fun WireMock.trace(specifyRequest: SpecifyRequest) = requestServerBuilderStep(specifyRequest, WireMock::trace)
 fun WireMock.any(specifyRequest: SpecifyRequest) = requestServerBuilderStep(specifyRequest, WireMock::any)
+
+fun DslWrapper.get(specifyRequest: SpecifyRequest) = requestServerBuilderStep(specifyRequest, WireMock::get)
+fun DslWrapper.post(specifyRequest: SpecifyRequest) = requestServerBuilderStep(specifyRequest, WireMock::post)
+fun DslWrapper.put(specifyRequest: SpecifyRequest) = requestServerBuilderStep(specifyRequest, WireMock::put)
+fun DslWrapper.patch(specifyRequest: SpecifyRequest) = requestServerBuilderStep(specifyRequest, WireMock::patch)
+fun DslWrapper.delete(specifyRequest: SpecifyRequest) = requestServerBuilderStep(specifyRequest, WireMock::delete)
+fun DslWrapper.head(specifyRequest: SpecifyRequest) = requestServerBuilderStep(specifyRequest, WireMock::head)
+fun DslWrapper.options(specifyRequest: SpecifyRequest) = requestServerBuilderStep(specifyRequest, WireMock::options)
+fun DslWrapper.trace(specifyRequest: SpecifyRequest) = requestServerBuilderStep(specifyRequest, WireMock::trace)
+fun DslWrapper.any(specifyRequest: SpecifyRequest) = requestServerBuilderStep(specifyRequest, WireMock::any)
+
 fun WireMockServer.get(specifyRequest: SpecifyRequest) = requestServerBuilderStep(specifyRequest, WireMock::get)
 fun WireMockServer.post(specifyRequest: SpecifyRequest) = requestServerBuilderStep(specifyRequest, WireMock::post)
 fun WireMockServer.put(specifyRequest: SpecifyRequest) = requestServerBuilderStep(specifyRequest, WireMock::put)
@@ -49,6 +61,15 @@ private fun WireMock.requestServerBuilderStep(
         specifyRequestList = listOf(specifyRequest)
 )
 
+private fun DslWrapper.requestServerBuilderStep(
+        specifyRequest: SpecifyRequest,
+        method: Method
+) = BuildingStep(
+        wireMockInstance = WiremockDslWrapperInstance(this),
+        method = method,
+        specifyRequestList = listOf(specifyRequest)
+)
+
 fun WireMockServer.requestServerBuilderStep(
     specifyRequest: SpecifyRequest,
     method: Method
@@ -62,7 +83,7 @@ private fun requestDefaultBuilderStep(
     specifyRequest: SpecifyRequest,
     method: Method
 ) = BuildingStep(
-    wireMockInstance = WiremockDefaultInstance,
+    wireMockInstance = WiremockDefaultInstance(),
     method = method,
     specifyRequestList = listOf(specifyRequest)
 )

--- a/src/main/kotlin/com/marcinziolo/kotlin/wiremock/api.kt
+++ b/src/main/kotlin/com/marcinziolo/kotlin/wiremock/api.kt
@@ -12,6 +12,15 @@ typealias SpecifyRequest = RequestSpecification.() -> Unit
 typealias SpecifyResponse = ResponseSpecification.() -> Unit
 typealias Method = (UrlPathPattern) -> MappingBuilder
 
+fun WireMock.get(specifyRequest: SpecifyRequest) = requestServerBuilderStep(specifyRequest, WireMock::get)
+fun WireMock.post(specifyRequest: SpecifyRequest) = requestServerBuilderStep(specifyRequest, WireMock::post)
+fun WireMock.put(specifyRequest: SpecifyRequest) = requestServerBuilderStep(specifyRequest, WireMock::put)
+fun WireMock.patch(specifyRequest: SpecifyRequest) = requestServerBuilderStep(specifyRequest, WireMock::patch)
+fun WireMock.delete(specifyRequest: SpecifyRequest) = requestServerBuilderStep(specifyRequest, WireMock::delete)
+fun WireMock.head(specifyRequest: SpecifyRequest) = requestServerBuilderStep(specifyRequest, WireMock::head)
+fun WireMock.options(specifyRequest: SpecifyRequest) = requestServerBuilderStep(specifyRequest, WireMock::options)
+fun WireMock.trace(specifyRequest: SpecifyRequest) = requestServerBuilderStep(specifyRequest, WireMock::trace)
+fun WireMock.any(specifyRequest: SpecifyRequest) = requestServerBuilderStep(specifyRequest, WireMock::any)
 fun WireMockServer.get(specifyRequest: SpecifyRequest) = requestServerBuilderStep(specifyRequest, WireMock::get)
 fun WireMockServer.post(specifyRequest: SpecifyRequest) = requestServerBuilderStep(specifyRequest, WireMock::post)
 fun WireMockServer.put(specifyRequest: SpecifyRequest) = requestServerBuilderStep(specifyRequest, WireMock::put)
@@ -31,7 +40,16 @@ fun mockOptions(specifyRequest: SpecifyRequest) = requestDefaultBuilderStep(spec
 fun mockTrace(specifyRequest: SpecifyRequest) = requestDefaultBuilderStep(specifyRequest, WireMock::trace)
 fun mockAny(specifyRequest: SpecifyRequest) = requestDefaultBuilderStep(specifyRequest, WireMock::any)
 
-private fun WireMockServer.requestServerBuilderStep(
+private fun WireMock.requestServerBuilderStep(
+        specifyRequest: SpecifyRequest,
+        method: Method
+) = BuildingStep(
+        wireMockInstance = WiremockClientInstance(this),
+        method = method,
+        specifyRequestList = listOf(specifyRequest)
+)
+
+fun WireMockServer.requestServerBuilderStep(
     specifyRequest: SpecifyRequest,
     method: Method
 ) = BuildingStep(

--- a/src/test/kotlin/com/marcinziolo/kotlin/wiremock/Junit5ExtensionTest.kt
+++ b/src/test/kotlin/com/marcinziolo/kotlin/wiremock/Junit5ExtensionTest.kt
@@ -1,0 +1,39 @@
+package com.marcinziolo.kotlin.wiremock
+
+import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo
+import com.github.tomakehurst.wiremock.junit5.WireMockTest
+import io.restassured.module.kotlin.extensions.Then
+import io.restassured.module.kotlin.extensions.When
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+@WireMockTest
+class Junit5ExtensionTest {
+
+    lateinit var wm: WireMock
+    lateinit var baseUrl: String
+
+    @BeforeEach
+    fun setup(wireMockRuntimeInfo: WireMockRuntimeInfo){
+        wm = wireMockRuntimeInfo.wireMock
+        baseUrl = wireMockRuntimeInfo.httpBaseUrl
+    }
+
+    @Test
+    fun testGet() {
+        wm.get {
+            url equalTo "/hello"
+        } returns {
+            statusCode = 200
+        }
+
+        When {
+            get("$baseUrl/hello")
+        } Then {
+            statusCode(200)
+        }
+    }
+
+
+}

--- a/src/test/kotlin/com/marcinziolo/kotlin/wiremock/Junit5RegisterExtensionTest.kt
+++ b/src/test/kotlin/com/marcinziolo/kotlin/wiremock/Junit5RegisterExtensionTest.kt
@@ -1,0 +1,43 @@
+package com.marcinziolo.kotlin.wiremock
+
+import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo
+import com.github.tomakehurst.wiremock.junit5.WireMockTest
+import io.restassured.module.kotlin.extensions.Then
+import io.restassured.module.kotlin.extensions.When
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+
+
+class Junit5RegisterExtensionTest {
+
+    @JvmField
+    @RegisterExtension
+    var wm = WireMockExtension.newInstance()
+            .options(wireMockConfig().dynamicPort())
+            .build()
+
+    @BeforeEach
+    fun setup(){
+    }
+
+    @Test
+    fun testGet() {
+        wm.get {
+            url equalTo "/hello"
+        } returns {
+            statusCode = 200
+        }
+
+        When {
+            get("${wm.baseUrl()}/hello")
+        } Then {
+            statusCode(200)
+        }
+    }
+
+
+}


### PR DESCRIPTION
This enables normal client calls to the WireMock server.

This also means that the `JUnit 5` support is more flexible since it doesn't rely on the default server anymore. 

```kotlin
@WireMockTest
class ExampleExtensionTest {

    lateinit var wm: String

    @BeforeEach
    fun urlSetup(wmRuntimeInfo: WireMockRuntimeInfo) {
        wm = wmRuntimeInfo.wireMock
    }

    @Test
    fun `url equalTo`() {
        wm.get {     //     <----- Can use Wiremock instance directly
            url equalTo "/users/1"
        } returns {
            header = "Content-Type" to "application/json"
            statusCode = 200
            body = """
            {
              "id": 1,
              "name": "Bob"
            }
            """
        }

        When {
            get("$url/users/1")
        } Then {
            statusCode(200)
            body("id", equalTo(1))
            body("name", equalTo("Bob"))
        }
    }
}
```