### PR TITLE
Add support for verification in DSL

### DIFF
--- a/src/main/kotlin/com/marcinziolo/kotlin/wiremock/VerificationDsl.kt
+++ b/src/main/kotlin/com/marcinziolo/kotlin/wiremock/VerificationDsl.kt
@@ -1,0 +1,133 @@
+package com.marcinziolo.kotlin.wiremock
+
+import com.github.tomakehurst.wiremock.client.CountMatchingMode
+import com.github.tomakehurst.wiremock.client.CountMatchingStrategy
+import com.github.tomakehurst.wiremock.client.CountMatchingStrategy.*
+import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.http.RequestMethod
+import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder
+
+class VerificationDsl {
+
+
+    enum class MatchMode {
+        EQUAL_TO,
+        PATTERN,
+        PATH_EQUAL_TO,
+        PATH_PATTERN,
+        ANY,
+    }
+
+    class Verification(
+            var count: CountMatchingStrategy,
+            val requestBuilder: RequestPatternBuilder,
+            var block: RequestPatternBuilder.() -> Unit,
+    ) {
+
+    }
+
+    data class VerifyDsl(
+            internal val verifications: MutableList<Verification> = mutableListOf()
+    ) {
+        fun addVerification(url: String = "", match: MatchMode = MatchMode.EQUAL_TO,
+                            atLeast:Int? = null, atMost:Int? = null, exactly:Int?=null,
+                            method: RequestMethod, block: RequestPatternBuilder.() -> Unit) {
+            val urlPattern = when (match) {
+                MatchMode.EQUAL_TO -> WireMock.urlEqualTo(url)
+                MatchMode.PATTERN -> WireMock.urlMatching(url)
+                MatchMode.PATH_EQUAL_TO -> WireMock.urlPathEqualTo(url)
+                MatchMode.PATH_PATTERN -> WireMock.urlPathMatching(url)
+                MatchMode.ANY -> WireMock.anyUrl()
+            }
+
+            val count = when {
+                exactly != null -> CountMatchingStrategy(EQUAL_TO, exactly)
+                atLeast != null && atMost != null -> CountingStrategyWith(atLeast, atMost)
+                atLeast != null -> CountMatchingStrategy(GREATER_THAN_OR_EQUAL, atLeast)
+                atMost != null -> CountMatchingStrategy(LESS_THAN_OR_EQUAL, atMost)
+                else -> CountMatchingStrategy(GREATER_THAN_OR_EQUAL, 1)
+            }
+
+            verifications.add(Verification(count, RequestPatternBuilder(method, urlPattern), block))
+        }
+
+        class CountingStrategyWith(private val atLeast: Int, private val atMost: Int):
+                CountMatchingStrategy(CountWithin(atLeast, atMost), atLeast){
+            init {
+                if(atLeast > atMost) {
+                    throw IllegalArgumentException("In verification 'atLeast' cannot be greater than 'atMost' (atLeast=$atLeast atMost=$atMost)")
+                }
+            }
+
+            override fun match(actual: Int): Boolean {
+                return actual in atLeast..atMost
+            }
+        }
+
+        class CountWithin(private val atLeast: Int, private val atMost: Int) : CountMatchingMode {
+            override fun test(actual: Int?, expected: Int?): Boolean {
+                error("Not used. Use CountingStrategyWith instead")
+            }
+
+            override fun getFriendlyName()= "Within ($atLeast..$atMost)"
+
+        }
+
+        fun get(url: String = "/.*", match: MatchMode = MatchMode.PATTERN,
+                atLeast:Int? = null, atMost:Int? = null, exactly:Int?=null,
+                block: RequestPatternBuilder.() -> Unit = {}) {
+            addVerification(url, match, atLeast, atMost, exactly, RequestMethod.GET, block)
+        }
+
+        fun post(url: String = "", match: MatchMode = MatchMode.EQUAL_TO,
+                 atLeast:Int? = null, atMost:Int? = null, exactly:Int?=null,
+                 block: RequestPatternBuilder.() -> Unit) {
+            addVerification(url, match, atLeast, atMost, exactly, RequestMethod.POST, block)
+        }
+
+        fun put(url: String = "", match: MatchMode = MatchMode.EQUAL_TO,
+                atLeast:Int? = null, atMost:Int? = null, exactly:Int?=null,
+                block: RequestPatternBuilder.() -> Unit) {
+            addVerification(url, match, atLeast, atMost, exactly, RequestMethod.PUT, block)
+        }
+
+        fun delete(url: String = "", match: MatchMode = MatchMode.EQUAL_TO,
+                   atLeast:Int? = null, atMost:Int? = null, exactly:Int?=null,
+                   block: RequestPatternBuilder.() -> Unit) {
+            addVerification(url, match, atLeast, atMost, exactly, RequestMethod.DELETE, block)
+        }
+
+        fun head(url: String = "", match: MatchMode = MatchMode.EQUAL_TO,
+                 atLeast:Int? = null, atMost:Int? = null, exactly:Int?=null,
+                 block: RequestPatternBuilder.() -> Unit) {
+            addVerification(url, match, atLeast, atMost, exactly, RequestMethod.HEAD, block)
+        }
+
+        fun options(url: String = "", match: MatchMode = MatchMode.EQUAL_TO,
+                    atLeast:Int? = null, atMost:Int? = null, exactly:Int?=null,
+                    block: RequestPatternBuilder.() -> Unit) {
+            addVerification(url, match, atLeast, atMost, exactly, RequestMethod.OPTIONS, block)
+        }
+
+        fun patch(url: String = "", match: MatchMode = MatchMode.EQUAL_TO,
+                  atLeast:Int? = null, atMost:Int? = null, exactly:Int?=null,
+                  block: RequestPatternBuilder.() -> Unit) {
+            addVerification(url, match, atLeast, atMost, exactly, RequestMethod.PATCH, block)
+        }
+
+        fun trace(url: String = "", match: MatchMode = MatchMode.EQUAL_TO,
+                  atLeast:Int? = null, atMost:Int? = null, exactly:Int?=null,
+                  block: RequestPatternBuilder.() -> Unit) {
+            addVerification(url, match, atLeast, atMost, exactly, RequestMethod.TRACE, block)
+        }
+
+        fun any(url: String = "", match: MatchMode = MatchMode.EQUAL_TO,
+                atLeast:Int? = null, atMost:Int? = null, exactly:Int?=null,
+                block: RequestPatternBuilder.() -> Unit) {
+            addVerification(url, match, atLeast, atMost, exactly, RequestMethod.ANY, block)
+        }
+    }
+
+
+
+}

--- a/src/main/kotlin/com/marcinziolo/kotlin/wiremock/WireMockInstance.kt
+++ b/src/main/kotlin/com/marcinziolo/kotlin/wiremock/WireMockInstance.kt
@@ -1,9 +1,11 @@
 package com.marcinziolo.kotlin.wiremock
 
 import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.CountMatchingStrategy
 import com.github.tomakehurst.wiremock.client.MappingBuilder
 import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.junit.DslWrapper
+import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
 import java.util.UUID
 
@@ -11,28 +13,38 @@ interface WireMockInstance {
     fun stubFor(mappingBuilder: MappingBuilder): StubMapping
     fun removeStubMapping(stubMapping: StubMapping)
     fun getSingleStubMapping(uuid: UUID): StubMapping
+    fun verify(countMatchingStrategy: CountMatchingStrategy, requestPatternBuilder: RequestPatternBuilder)
+
 }
 
 object WiremockDefaultInstance: WireMockInstance {
     override fun stubFor(mappingBuilder: MappingBuilder) = WireMock.stubFor(mappingBuilder)
     override fun removeStubMapping(stubMapping: StubMapping) = WireMock.removeStub(stubMapping)
     override fun getSingleStubMapping(uuid: UUID) = WireMock.getSingleStubMapping(uuid)
+    override fun verify(countMatchingStrategy: CountMatchingStrategy, requestPatternBuilder: RequestPatternBuilder) =
+            WireMock.verify(countMatchingStrategy, requestPatternBuilder)
 }
 
 class WiremockServerInstance(private val wireMockServer: WireMockServer): WireMockInstance {
     override fun stubFor(mappingBuilder: MappingBuilder) = wireMockServer.stubFor(mappingBuilder)
     override fun removeStubMapping(stubMapping: StubMapping) = wireMockServer.removeStub(stubMapping)
     override fun getSingleStubMapping(uuid: UUID) = wireMockServer.getSingleStubMapping(uuid)
+    override fun verify(countMatchingStrategy: CountMatchingStrategy, requestPatternBuilder: RequestPatternBuilder) =
+            wireMockServer.verify(countMatchingStrategy, requestPatternBuilder)
 }
 
 class WiremockClientInstance(private val wireMock: WireMock): WireMockInstance {
     override fun stubFor(mappingBuilder: MappingBuilder) = wireMock.register(mappingBuilder)
     override fun removeStubMapping(stubMapping: StubMapping) = wireMock.removeStubMapping(stubMapping)
     override fun getSingleStubMapping(uuid: UUID) = wireMock.getStubMapping(uuid).item
+    override fun verify(countMatchingStrategy: CountMatchingStrategy, requestPatternBuilder: RequestPatternBuilder) =
+            wireMock.verifyThat(countMatchingStrategy, requestPatternBuilder)
 }
 
 class WiremockDslWrapperInstance(private val dslWrapper: DslWrapper): WireMockInstance {
     override fun stubFor(mappingBuilder: MappingBuilder) = dslWrapper.stubFor(mappingBuilder)
     override fun removeStubMapping(stubMapping: StubMapping) = dslWrapper.removeStub(stubMapping)
     override fun getSingleStubMapping(uuid: UUID) = dslWrapper.getSingleStubMapping(uuid)
+    override fun verify(countMatchingStrategy: CountMatchingStrategy, requestPatternBuilder: RequestPatternBuilder) =
+            dslWrapper.verify(countMatchingStrategy, requestPatternBuilder)
 }

--- a/src/main/kotlin/com/marcinziolo/kotlin/wiremock/api.kt
+++ b/src/main/kotlin/com/marcinziolo/kotlin/wiremock/api.kt
@@ -21,6 +21,7 @@ fun WireMock.head(specifyRequest: SpecifyRequest) = requestServerBuilderStep(spe
 fun WireMock.options(specifyRequest: SpecifyRequest) = requestServerBuilderStep(specifyRequest, WireMock::options)
 fun WireMock.trace(specifyRequest: SpecifyRequest) = requestServerBuilderStep(specifyRequest, WireMock::trace)
 fun WireMock.any(specifyRequest: SpecifyRequest) = requestServerBuilderStep(specifyRequest, WireMock::any)
+fun WireMock.verify(block: VerificationDsl.VerifyDsl.() -> Unit) = verify(WiremockClientInstance(this), block)
 
 fun DslWrapper.get(specifyRequest: SpecifyRequest) = requestServerBuilderStep(specifyRequest, WireMock::get)
 fun DslWrapper.post(specifyRequest: SpecifyRequest) = requestServerBuilderStep(specifyRequest, WireMock::post)
@@ -31,6 +32,7 @@ fun DslWrapper.head(specifyRequest: SpecifyRequest) = requestServerBuilderStep(s
 fun DslWrapper.options(specifyRequest: SpecifyRequest) = requestServerBuilderStep(specifyRequest, WireMock::options)
 fun DslWrapper.trace(specifyRequest: SpecifyRequest) = requestServerBuilderStep(specifyRequest, WireMock::trace)
 fun DslWrapper.any(specifyRequest: SpecifyRequest) = requestServerBuilderStep(specifyRequest, WireMock::any)
+fun DslWrapper.verify(block: VerificationDsl.VerifyDsl.() -> Unit) = verify(WiremockDslWrapperInstance(this), block)
 
 fun WireMockServer.get(specifyRequest: SpecifyRequest) = requestServerBuilderStep(specifyRequest, WireMock::get)
 fun WireMockServer.post(specifyRequest: SpecifyRequest) = requestServerBuilderStep(specifyRequest, WireMock::post)
@@ -41,6 +43,7 @@ fun WireMockServer.head(specifyRequest: SpecifyRequest) = requestServerBuilderSt
 fun WireMockServer.options(specifyRequest: SpecifyRequest) = requestServerBuilderStep(specifyRequest, WireMock::options)
 fun WireMockServer.trace(specifyRequest: SpecifyRequest) = requestServerBuilderStep(specifyRequest, WireMock::trace)
 fun WireMockServer.any(specifyRequest: SpecifyRequest) = requestServerBuilderStep(specifyRequest, WireMock::any)
+fun WireMockServer.verify(block: VerificationDsl.VerifyDsl.() -> Unit) = verify(WiremockServerInstance(this), block)
 
 fun mockGet(specifyRequest: SpecifyRequest) = requestDefaultBuilderStep(specifyRequest, WireMock::get)
 fun mockPost(specifyRequest: SpecifyRequest) = requestDefaultBuilderStep(specifyRequest, WireMock::post)
@@ -51,6 +54,18 @@ fun mockHead(specifyRequest: SpecifyRequest) = requestDefaultBuilderStep(specify
 fun mockOptions(specifyRequest: SpecifyRequest) = requestDefaultBuilderStep(specifyRequest, WireMock::options)
 fun mockTrace(specifyRequest: SpecifyRequest) = requestDefaultBuilderStep(specifyRequest, WireMock::trace)
 fun mockAny(specifyRequest: SpecifyRequest) = requestDefaultBuilderStep(specifyRequest, WireMock::any)
+fun verifyCalls(block: VerificationDsl.VerifyDsl.() -> Unit) = verify(WiremockDefaultInstance, block)
+
+private fun verify(wm: WireMockInstance, block: VerificationDsl.VerifyDsl.() -> Unit) {
+    val dsl = VerificationDsl.VerifyDsl()
+    dsl.block()
+    dsl.verifications.forEach {
+        val builderBlock = it.block
+        it.requestBuilder.builderBlock()
+        wm.verify(it.count, it.requestBuilder)
+    }
+}
+
 
 private fun WireMock.requestServerBuilderStep(
         specifyRequest: SpecifyRequest,

--- a/src/test/kotlin/com/marcinziolo/kotlin/wiremock/VerificationTest.kt
+++ b/src/test/kotlin/com/marcinziolo/kotlin/wiremock/VerificationTest.kt
@@ -1,0 +1,71 @@
+package com.marcinziolo.kotlin.wiremock
+
+import com.github.tomakehurst.wiremock.client.VerificationException
+import io.restassured.module.kotlin.extensions.Then
+import io.restassured.module.kotlin.extensions.When
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class VerificationTest : AbstractTest() {
+
+    @Test
+    fun `multiple verifications can be called individually or together`() {
+        setupWiremockAndCallIt()
+
+        wiremock.verify { get(exactly = 1) }
+        wiremock.verify { get("/hello") }
+        wiremock.verify {
+            get("/hello", atLeast = 1)
+            get("/hello", atMost = 1)
+            get("/hello", exactly = 1)
+            get("/hello", atLeast = 0, atMost = 10)
+        }
+    }
+
+
+    @Test
+    fun `count verifications can be called should fail when incorrect`() {
+        setupWiremockAndCallIt()
+
+        assertThrows<VerificationException> { wiremock.verify { get("/hello", atLeast = 2) } }
+        assertThrows<VerificationException> { wiremock.verify { get("/hello", atMost = 0) } }
+        assertThrows<VerificationException> { wiremock.verify { get("/hello", exactly = 4) } }
+        assertThrows<VerificationException> { wiremock.verify { get("/hello", atLeast = 3, atMost = 10) } }
+    }
+
+    @Test
+    fun `atLeast must be less than atMost`() {
+        assertThrows<IllegalArgumentException> { wiremock.verify { get("/hello", atLeast = 10, atMost = 1) } }
+    }
+
+    @Test
+    fun `response with two headers`() {
+        setupWiremockAndCallIt()
+
+//        wiremock.verify(1, getRequestedFor(urlEqualTo("/hello")))
+
+        wiremock.verify {
+            get("/hello", atLeast = 1)
+            assertThrows<IllegalArgumentException> { get(atLeast = 5, atMost = 2) }
+        }
+    }
+
+    private fun setupWiremockAndCallIt() {
+        wiremock.get {
+            url equalTo "/hello"
+        } returns {
+            statusCode = 200
+            header = "TraceId" to "abcd123"
+            header = "ExecutionTime" to "10"
+        }
+
+        When {
+            get("$url/hello")
+        } Then {
+            statusCode(200)
+            header("TraceId", "abcd123")
+            header("ExecutionTime", "10")
+        }
+    }
+
+}


### PR DESCRIPTION
Addresses #15 

Once the other PRs are merged, this one will have conflicts and need to be tweaked.

The DSL is written in a slightly different style to the other parts of the DSL. I mimicked the `verify` approach used by [mockk](https://blog.kotlin-academy.com/mocking-is-not-rocket-science-expected-behavior-and-behavior-verification-3862dd0e0f03)

Mockk:
```kotlin
verify(atLeast = 5, atMost = 7) { mock1.call(5) }
```

Wiremock verification:
```kotlin
wiremock.verify { get("/hello", atLeast=1, atMost=3) }

// Or with the default wiremock
verifyCalls { get("/hello") }
```