### PR TITLE
feat: Support wiremock 3.0.0 and Jetty 11

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,14 +33,14 @@ dependencies {
     implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
 
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
-    api("com.github.tomakehurst:wiremock-jre8:2.33.2")
+    api("com.github.tomakehurst:wiremock:3.0.0-beta-2")
 
     testImplementation("io.rest-assured:rest-assured:5.1.1")
     testImplementation("io.rest-assured:json-path:5.1.1")
     testImplementation("io.rest-assured:kotlin-extensions:5.1.1")
     testImplementation("org.junit.jupiter:junit-jupiter:5.6.2")
     testImplementation("io.mockk:mockk:1.12.4")
-    testImplementation("com.github.tomakehurst:wiremock-jre8:2.33.2")
+    testImplementation("com.github.tomakehurst:wiremock:3.0.0-beta-2")
 }
 
 tasks.test {


### PR DESCRIPTION
We are using this project (🙏 thanks!) for testing along side our [Javalin](https://javalin.io/) servers. The v5 version of Javalin recently deprecated < Jetty 10 which causes conflicts with the jetty dependencies pulled in from this library. Wiremock recently cut a beta release for 3.0.0 which also supports Jetty 11.

I went ahead and updated the dependencies here and all tests still pass. Would it be possible to cut a version with this update?